### PR TITLE
Stop iteration within _parse if the parser has been destroyed

### DIFF
--- a/lib/json.js
+++ b/lib/json.js
@@ -81,6 +81,9 @@ Parser.prototype._parse = function(data) {
 
   for (; i < l; i++) {
     ch = data[i];
+    if (!this.writable && !this.readable) {
+      return
+    }
     switch (this.state) {
       case 'value': {
         switch (ch) {
@@ -539,7 +542,9 @@ exports.handle = function(req, res, next, options) {
   });
 
   parser.on('error', function(err) {
-    req.destroy();
+    if (typeof options.handleInvalidJson === 'function') {
+      return options.handleInvalidJson(err, req, res, next);
+    }
     next(err);
   });
 


### PR DESCRIPTION
Previously the parser would throw an error on input such as: `{"some": "value", "o": {"a"]: {` because multiple calls to Parser._unexpected are made. The first call to _unexpected results in the parser being destroyed which de-registers the error handler and thus the second call to _unexpected results in the error being thrown due by the EventEmitter.

Its clear from the existing code within the main loop of _parse that the loop is meant to stop when _unexpected is called. However, in this case, _unexpected is called within the handler of the `object create` event which means that the loop is allowed to continue even after the parser has been destroyed() and reset().

This PR adds a check to the start of the for loop to ensure this case is correctly handled.