### PR TITLE
(API-744) Increase buffer size when parsing

### DIFF
--- a/lib/multipart.js
+++ b/lib/multipart.js
@@ -22,6 +22,12 @@ var DASH = '-'.charCodeAt(0)
   , SPACE = ' '.charCodeAt(0);
 
 /**
+ * Size of the buffer
+ */
+
+var BUFFER_SIZE = 1000;
+
+/**
  * Parser
  */
 
@@ -56,7 +62,7 @@ var Parser = function(type, options) {
   this.pending = 0;
   this.written = 0;
   this.writtenDisk = 0;
-  this.buff = new Buffer(200);
+  this.buff = new Buffer(BUFFER_SIZE);
 
   this.preamble = true;
   this.epilogue = false;
@@ -108,7 +114,7 @@ Parser.prototype._parse = function(data) {
     , j;
 
   for (; i < len; i++) {
-    if (this.pos >= 200) {
+    if (this.pos >= BUFFER_SIZE) {
       return this._error('Potential buffer overflow.');
     }
 


### PR DESCRIPTION
Increase buffer size to support longer file names.

For example, `【履歴書・職務経歴書】_程.pdf` breaks the buffer when it is escaped